### PR TITLE
Firestore project: Import of API interfaces.

### DIFF
--- a/Firestore/core/include/firebase/firestore/CMakeLists.txt
+++ b/Firestore/core/include/firebase/firestore/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Hack to make the headers show up in IDEs
+# feature to make the headers show up in IDEs
 # (see https://stackoverflow.com/questions/27039019/ and open issue on CMake
 # issue tracker: https://gitlab.kitware.com/cmake/cmake/issues/15234)
 add_custom_target(firebase_firestore_types_ide SOURCES

--- a/Firestore/core/include/firebase/firestore/collection_reference.h
+++ b/Firestore/core/include/firebase/firestore/collection_reference.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_COLLECTION_REFERENCE_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_COLLECTION_REFERENCE_H_
+
+namespace firebase {
+namespace firestore {
+
+class CollectionReferenceInternal;
+class FirestoreInternal;
+
+/**
+ * A CollectionReference refers to a collection of documents location in a
+ * Firestore database and can be used for adding documents, getting document
+ * references, and querying for documents.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class CollectionReference {
+ public:
+  /**
+   * @brief Default constructor. This creates an invalid CollectionReference.
+   * Attempting to perform any operations on this reference will fail unless a
+   * valid CollectionReference has been assigned to it.
+   */
+  CollectionReference();
+
+  /**
+   * @brief Copy constructor. It's totally okay (and efficient) to copy
+   * CollectionReference instances, as they simply point to the same location in
+   * the database.
+   *
+   * @param[in] reference CollectionReference to copy from.
+   */
+  CollectionReference(const CollectionReference& reference);
+
+  /**
+   * @brief Move constructor. Moving is an efficient operation for
+   * CollectionReference instances.
+   *
+   * @param[in] reference CollectionReference to move data from.
+   */
+  CollectionReference(CollectionReference&& reference);
+
+  /** @brief Required virtual destructor. */
+  virtual ~CollectionReference();
+
+  /**
+   * @brief Copy assignment operator. It's totally okay (and efficient) to copy
+   * CollectionReference instances, as they simply point to the same location in
+   * the database.
+   *
+   * @param[in] reference CollectionReference to copy from.
+   *
+   * @returns Reference to the destination CollectionReference.
+   */
+  CollectionReference& operator=(const CollectionReference& reference);
+
+  /**
+   * @brief Move assignment operator. Moving is an efficient operation for
+   * CollectionReference instances.
+   *
+   * @param[in] reference CollectionReference to move data from.
+   *
+   * @returns Reference to the destination CollectionReference.
+   */
+  CollectionReference& operator=(CollectionReference&& reference);
+
+ protected:
+  explicit CollectionReference(CollectionReferenceInternal* internal);
+
+ private:
+  friend class DocumentReference;
+  friend class DocumentReferenceInternal;
+  friend class FirestoreInternal;
+
+  // TODO(zxu123): investigate possibility to use std::unique_ptr or
+  // firebase::UniquePtr.
+  CollectionReferenceInternal* internal_ = nullptr;
+};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_COLLECTION_REFERENCE_H_

--- a/Firestore/core/include/firebase/firestore/document_change.h
+++ b/Firestore/core/include/firebase/firestore/document_change.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_CHANGE_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_CHANGE_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A DocumentChange represents a change to the documents matching a query. It
+ * contains the document affected and the type of change that occurred (added,
+ * modified, or removed).
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class DocumentChange {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_CHANGE_H_

--- a/Firestore/core/include/firebase/firestore/document_reference.h
+++ b/Firestore/core/include/firebase/firestore/document_reference.h
@@ -16,7 +16,7 @@
 
 // TODO(rsgowman): This file isn't intended to be used just yet. It's just an
 // outline of what the API might eventually look like. Most of this was
-// shamelessly stolen and modified from RTDB's header file, melded with the
+// shamelessly stolen and modified from rtdb's header file, melded with the
 // (java) firestore api.
 
 #ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_REFERENCE_H_
@@ -29,6 +29,17 @@
 #include <functional>
 #endif
 
+#include "firebase/app.h"
+#include "firebase/firestore/collection_reference.h"
+#include "firebase/firestore/document_snapshot.h"
+#include "firebase/firestore/event_listener.h"
+#include "firebase/firestore/field_value.h"
+#include "firebase/firestore/firestore.h"
+#include "firebase/firestore/firestore_errors.h"
+#include "firebase/firestore/listener_registration.h"
+#include "firebase/firestore/set_options.h"
+#include "firebase/future.h"
+
 // TODO(rsgowman): Note that RTDB uses:
 //   #if defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN
 // to protect move operators from older compilers. But all our supported
@@ -36,34 +47,12 @@
 // here so we don't forget to mention this during the API review, and should be
 // removed once this note has migrated to the API review doc.
 
-// TODO(rsgowman): replace these forward decls with appropriate includes (once
-// they exist)
-namespace firebase {
-class App;
-template <typename T>
-class Future;
-}  // namespace firebase
-
 namespace firebase {
 namespace firestore {
 
-// TODO(rsgowman): replace these forward decls with appropriate includes (once
-// they exist)
-class FieldValue;
-class DocumentSnapshot;
+class DocumentReferenceInternal;
 class Firestore;
-class Error;
-template <typename T>
-class EventListener;
-class ListenerRegistration;
-class CollectionReference;
-class DocumentListenOptions;
-// TODO(rsgowman): not quite a forward decl, but required to make the default
-// parameter to Set() "compile".
-class SetOptions {
- public:
-  SetOptions();
-};
+class FirestoreInternal;
 
 // TODO(rsgowman): move this into the FieldValue header
 #ifdef STLPORT
@@ -80,12 +69,19 @@ using MapFieldValue = std::unordered_map<std::string, FieldValue>;
  *
  * Create a DocumentReference via Firebase::Document(const string& path).
  *
+ * NOT thread-safe: an instance should not be used from multiple threads
+ *
  * Subclassing Note: Firestore classes are not meant to be subclassed except for
  * use in test mocks. Subclassing is not supported in production code and new
  * SDK releases may break code that does so.
  */
 class DocumentReference {
  public:
+  enum class MetadataChanges {
+    kExclude,
+    kInclude,
+  };
+
   /**
    * @brief Default constructor. This creates an invalid DocumentReference.
    * Attempting to perform any operations on this reference will fail (and cause
@@ -269,28 +265,13 @@ class DocumentReference {
    * this DocumentReference. (Ownership is not transferred; you are responsible
    * for making sure that listener is valid as long as this DocumentReference is
    * valid and the listener is registered.)
+   * @param[in] option The option whether to listen metadata-changes or not.
    *
    * @return A registration object that can be used to remove the listener.
    */
   virtual ListenerRegistration AddSnapshotListener(
-      EventListener<DocumentSnapshot>* listener);
-
-  /**
-   * @brief Starts listening to the document referenced by this
-   * DocumentReference.
-   *
-   * @param[in] options The options to use for this listen.
-   * @param[in] listener The event listener that will be called with the
-   * snapshots, which must remain in memory until you remove the listener from
-   * this DocumentReference. (Ownership is not transferred; you are responsible
-   * for making sure that listener is valid as long as this DocumentReference is
-   * valid and the listener is registered.)
-   *
-   * @return A registration object that can be used to remove the listener.
-   */
-  virtual ListenerRegistration AddSnapshotListener(
-      const DocumentListenOptions& options,
-      EventListener<DocumentSnapshot>* listener);
+      EventListener<DocumentSnapshot>* listener,
+      MetadataChanges option = MetadataChanges::kExclude);
 
 #if defined(FIREBASE_USE_STD_FUNCTION) || defined(DOXYGEN)
   /**
@@ -299,6 +280,7 @@ class DocumentReference {
    *
    * @param[in] callback function or lambda to call. When this function is
    * called, exactly one of the parameters will be non-null.
+   * @param[in] option The option whether to listen metadata-changes or not.
    *
    * @return A registration object that can be used to remove the listener.
    *
@@ -306,28 +288,21 @@ class DocumentReference {
    * std::function is not supported on STLPort.
    */
   virtual ListenerRegistration AddSnapshotListener(
-      std::function<void(const DocumentSnapshot*, const Error*)> callback);
-
-  /**
-   * @brief Starts listening to the document referenced by this
-   * DocumentReference.
-   *
-   * @param[in] options The options to use for this listen.
-   * @param[in] callback function or lambda to call. When this function is
-   * called, exactly one of the parameters will be non-null.
-   *
-   * @return A registration object that can be used to remove the listener.
-   *
-   * @note This method is not available when using STLPort on Android, as
-   * std::function is not supported on STLPort.
-   */
-  virtual ListenerRegistration AddSnapshotListener(
-      const DocumentListenOptions& options,
-      std::function<void(const DocumentSnapshot*, const Error*)> callback);
+      std::function<void(const DocumentSnapshot*, const Error*)> callback,
+      MetadataChanges option = MetadataChanges::kExclude);
 #endif  // defined(FIREBASE_USE_STD_FUNCTION) || defined(DOXYGEN)
+
+ protected:
+  explicit DocumentReference(DocumentReferenceInternal* internal);
+
+ private:
+  friend class FirestoreInternal;
+
+  // TODO(zxu123): investigate possibility to use std::unique_ptr or
+  // firebase::UniquePtr.
+  DocumentReferenceInternal* internal_ = nullptr;
 };
 
-// TODO(rsgowman): probably define and inline here.
 bool operator==(const DocumentReference& lhs, const DocumentReference& rhs);
 
 inline bool operator!=(const DocumentReference& lhs,
@@ -361,7 +336,7 @@ namespace std {
 // C++ style guide. But we think this is probably ok in this case since:
 // a) It's the standard way of doing this outside of Google (as the style guide
 // itself points out), and
-// b) This has a straightforward hash function anyway (just hash the path) so I
+// b) This has a straightfoward hash function anyway (just hash the path) so I
 // don't think the concerns in the style guide are going to bite us.
 //
 // Raise this concern during the API review.

--- a/Firestore/core/include/firebase/firestore/document_snapshot.h
+++ b/Firestore/core/include/firebase/firestore/document_snapshot.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_SNAPSHOT_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_SNAPSHOT_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A DocumentSnapshot contains data read from a document in your Firestore
+ * database. The data can be extracted with the data() method or by using
+ * FooValue() to access a specific field, where Foo is the type of that field.
+ *
+ * For a DocumentSnapshot that points to a non-existing document, any data
+ * access will raise assertion. You can use the exists() method to explicitly
+ * verify a documents existence.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class DocumentSnapshot {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_DOCUMENT_SNAPSHOT_H_

--- a/Firestore/core/include/firebase/firestore/event_listener.h
+++ b/Firestore/core/include/firebase/firestore/event_listener.h
@@ -22,12 +22,10 @@
 #ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_EVENT_LISTENER_H_
 #define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_EVENT_LISTENER_H_
 
+#include "firebase/firestore/firestore_errors.h"
+
 namespace firebase {
 namespace firestore {
-
-// TODO(rsgowman): replace these forward decl's with appropriate includes (once
-// they exist)
-class Error;
 
 /**
  * @brief An interface for event listeners.
@@ -35,6 +33,7 @@ class Error;
 template <typename T>
 class EventListener {
  public:
+  virtual ~EventListener() {}
   /**
    * @brief OnEvent will be called with the new value or the error if an error
    * occurred.
@@ -44,7 +43,7 @@ class EventListener {
    * @param value The value of the event. null if there was an error.
    * @param error The error if there was error. null otherwise.
    */
-  void OnEvent(const T* value, const Error* error);
+  virtual void OnEvent(const T* value, const Error* error) = 0;
 };
 
 }  // namespace firestore

--- a/Firestore/core/include/firebase/firestore/field_path.h
+++ b/Firestore/core/include/firebase/firestore/field_path.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_PATH_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_PATH_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A FieldPath refers to a field in a document. The path may consist of a single
+ * field name (referring to a top level field in the document), or a list of
+ * field names (referring to a nested field in the document).
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class FieldPath {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_PATH_H_

--- a/Firestore/core/include/firebase/firestore/field_value.h
+++ b/Firestore/core/include/firebase/firestore/field_value.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_VALUE_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_VALUE_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * Sentinel values that can be used when writing document fields with setData()
+ * or updateData().
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class FieldValue {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIELD_VALUE_H_

--- a/Firestore/core/include/firebase/firestore/firestore.h
+++ b/Firestore/core/include/firebase/firestore/firestore.h
@@ -22,23 +22,19 @@
 #ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIRESTORE_H_
 #define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_FIRESTORE_H_
 
+#include <memory>
 #include <string>
 
-// TODO(rsgowman): replace these forward decl's with appropriate includes (once
-// they exist)
-namespace firebase {
-class App;
-class InitResult;
-}  // namespace firebase
+#include "firebase/app.h"
+#include "firebase/firestore/collection_reference.h"
+#include "firebase/firestore/document_reference.h"
+#include "firebase/firestore/settings.h"
 
 namespace firebase {
 namespace firestore {
 
-// TODO(rsgowman): replace these forward decl's with appropriate includes (once
-// they exist)
 class DocumentReference;
-class CollectionReference;
-class Settings;
+class FirestoreInternal;
 
 /**
  * @brief Entry point for the Firebase Firestore C++ SDK.
@@ -152,6 +148,16 @@ class Firestore {
 
   /** Globally enables / disables Firestore logging for the SDK. */
   static void set_logging_enabled(bool logging_enabled);
+
+  Firestore(const Firestore& src) = delete;
+  Firestore& operator=(const Firestore& src) = delete;
+
+ private:
+  Firestore(::firebase::App* app);
+
+  // TODO(zxu123): investigate possibility to use std::unique_ptr or
+  // firebase::UniquePtr.
+  FirestoreInternal* internal_ = nullptr;
 };
 
 }  // namespace firestore

--- a/Firestore/core/include/firebase/firestore/firestore_errors.h
+++ b/Firestore/core/include/firebase/firestore/firestore_errors.h
@@ -109,6 +109,9 @@ enum FirestoreErrorCode {
   Unauthenticated = 16
 };
 
+// TODO(zxu123): decide whether we actually want an Error class or just use enum.
+using Error = FirestoreErrorCode;
+
 }  // namespace firestore
 }  // namespace firebase
 

--- a/Firestore/core/include/firebase/firestore/listener_registration.h
+++ b/Firestore/core/include/firebase/firestore/listener_registration.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_LISTENER_REGISTRATION_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_LISTENER_REGISTRATION_H_
+
+namespace firebase {
+namespace firestore {
+
+class ListenerRegistrationInternal;
+
+/** Represents a listener that can be removed by calling remove. */
+class ListenerRegistration {
+ public:
+  /**
+   * @brief Default constructor. This creates a no-op instance.
+   */
+  ListenerRegistration();
+
+  /**
+   * @brief Copy constructor. It's totally okay to copy ListenerRegistration
+   * instances.
+   *
+   * @param[in] registration ListenerRegistration to copy from.
+   */
+  ListenerRegistration(const ListenerRegistration& registration);
+
+  /**
+   * @brief Move constructor. Moving is an efficient operation for
+   * ListenerRegistration instances.
+   *
+   * @param[in] registration ListenerRegistration to move data from.
+   */
+  ListenerRegistration(ListenerRegistration&& registration);
+
+  ~ListenerRegistration();
+
+  /**
+   * @brief Copy assignment operator. It's totally okay to copy
+   * ListenerRegistration instances.
+   *
+   * @param[in] registration ListenerRegistration to copy from.
+   *
+   * @returns Reference to the destination ListenerRegistration.
+   */
+  ListenerRegistration& operator=(const ListenerRegistration& registration);
+
+  /**
+   * @brief Move assignment operator. Moving is an efficient operation for
+   * ListenerRegistration instances.
+   *
+   * @param[in] registration ListenerRegistration to move data from.
+   *
+   * @returns Reference to the destination ListenerRegistration.
+   */
+  ListenerRegistration& operator=(ListenerRegistration&& registration);
+
+  /**
+   * Removes the listener being tracked by this ListenerRegistration. After the
+   * initial call, subsequent calls have no effect.
+   */
+  void Remove();
+
+ private:
+  friend class DocumentReferenceInternal;
+  friend class ListenerRegistrationInternal;
+  friend class FirestoreInternal;
+
+  explicit ListenerRegistration(ListenerRegistrationInternal* internal);
+
+  ListenerRegistrationInternal* internal_ = nullptr;
+};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_LISTENER_REGISTRATION_H_

--- a/Firestore/core/include/firebase/firestore/query.h
+++ b/Firestore/core/include/firebase/firestore/query.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A Query refers to a Query which you can read or listen to. You can also
+ * construct refined Query objects by adding filters and ordering.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class Query {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_H_

--- a/Firestore/core/include/firebase/firestore/query_snapshot.h
+++ b/Firestore/core/include/firebase/firestore/query_snapshot.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_SNAPSHOT_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_SNAPSHOT_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A QuerySnapshot contains zero or more DocumentSnapshot objects. It can be
+ * iterated using foreach loop and its size can be inspected with empty() and
+ * count().
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class QuerySnapshot {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_QUERY_SNAPSHOT_H_

--- a/Firestore/core/include/firebase/firestore/set_options.h
+++ b/Firestore/core/include/firebase/firestore/set_options.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SET_OPTIONS_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SET_OPTIONS_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * An options object that configures the behavior of Set() calls. By providing
+ * the SetOptions objects returned by Merge(), the Set() methods in
+ * DocumentReference, WriteBatch and Transaction can be configured to perform
+ * granular merges instead of overwriting the target documents in their
+ * entirety.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class SetOptions {
+ public:
+  SetOptions();
+};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SET_OPTIONS_H_

--- a/Firestore/core/include/firebase/firestore/settings.h
+++ b/Firestore/core/include/firebase/firestore/settings.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SETTINGS_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SETTINGS_H_
+
+namespace firebase {
+namespace firestore {
+
+class SettingsInternal;
+
+/** Settings used to configure a Firestore instance. */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class Settings {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SETTINGS_H_

--- a/Firestore/core/include/firebase/firestore/snapshot_metadata.h
+++ b/Firestore/core/include/firebase/firestore/snapshot_metadata.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SNAPSHOT_METADATA_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SNAPSHOT_METADATA_H_
+
+namespace firebase {
+namespace firestore {
+
+/** Metadata about a snapshot, describing the state of the snapshot. */
+class SnapshotMetadata {
+ public:
+  SnapshotMetadata(bool has_pending_writes, bool is_from_cache)
+      : has_pending_writes_(has_pending_writes),
+        is_from_cache_(is_from_cache) {}
+
+  bool has_pending_writes() const { return has_pending_writes_; }
+
+  bool is_from_cache() const { return is_from_cache_; }
+
+ private:
+  const bool has_pending_writes_;
+  const bool is_from_cache_;
+};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_SNAPSHOT_METADATA_H_

--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -17,13 +17,13 @@
 #ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_TIMESTAMP_H_
 #define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_TIMESTAMP_H_
 
-#include <cstdint>
-#include <ctime>
-#include <string>
-
+#include <stdint.h>
+#include <time.h>
 #if !defined(_STLPORT_VERSION)
 #include <chrono>  // NOLINT(build/c++11)
 #endif             // !defined(_STLPORT_VERSION)
+#include <limits>
+#include <string>
 
 namespace firebase {
 
@@ -191,13 +191,13 @@ std::chrono::time_point<Clock, Duration> Timestamp::ToTimePoint() const {
   using TimePoint = chr::time_point<Clock, Duration>;
 
   // Saturate on overflow
-  const auto max_seconds = chr::duration_cast<chr::seconds>(Duration::max());
-  if (seconds_ > 0 && max_seconds.count() <= seconds_) {
-    return TimePoint{Duration::max()};
+  const auto max_value = std::numeric_limits<typename Duration::rep>::max();
+  if (seconds_ > 0 && max_value / Duration::period::den <= seconds_) {
+    return TimePoint{Duration(max_value)};
   }
-  const auto min_seconds = chr::duration_cast<chr::seconds>(Duration::min());
-  if (seconds_ < 0 && min_seconds.count() >= seconds_) {
-    return TimePoint{Duration::min()};
+  const auto min_value = std::numeric_limits<typename Duration::rep>::min();
+  if (seconds_ < 0 && min_value / Duration::period::den >= seconds_) {
+    return TimePoint{Duration(min_value)};
   }
 
   const auto seconds = chr::duration_cast<Duration>(chr::seconds(seconds_));

--- a/Firestore/core/include/firebase/firestore/transaction.h
+++ b/Firestore/core/include/firebase/firestore/transaction.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_TRANSACTION_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_TRANSACTION_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * Transaction provides methods to read and write data within a transaction.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class Transaction {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_TRANSACTION_H_

--- a/Firestore/core/include/firebase/firestore/write_batch.h
+++ b/Firestore/core/include/firebase/firestore/write_batch.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_WRITE_BATCH_H_
+#define FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_WRITE_BATCH_H_
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A write batch is used to perform multiple writes as a single atomic unit.
+ *
+ * A WriteBatch object provides methods for adding writes to the write batch.
+ * None of the writes will be committed (or visible locally) until commit() is
+ * called.
+ *
+ * Unlike transactions, write batches are persisted offline and therefore are
+ * preferable when you don't need to condition your writes on read data.
+ */
+// TODO(zxu123): add more methods to complete the class and make it useful.
+class WriteBatch {};
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_INCLUDE_FIREBASE_FIRESTORE_WRITE_BATCH_H_


### PR DESCRIPTION
--
197713382 by zxu <zxu>:

Implement more on listener class and implement ListenerRegistration.

TESTED:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/testapp:android_testapp_test --config=android_x86 --define firebase_build=stable
blaze test //sensored/cpp:firestore_kokoro
blaze test //sensored/cpp:listener_registration_test
--
196551381 by zxu <zxu>:

Implement more on listener class and implement the DocumentReference::AddSnapshotListener.

Also added a few test case and fixed a bug in DocumentReferenceInternal.

ListenerRegistration will be implemented in subsequent CL.

TESTED:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/testapp:android_testapp_test --config=android_x86 --define firebase_build=stable
blaze test //sensored/cpp:firestore_kokoro
blaze test //sensored/cpp:firestore_test
--
196276752 by zxu <zxu>:

Implement the SnapshotMetadata with inline methods and (non-)Wrapper for Firestore C++.

TESTED:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/testapp:android_testapp_test --config=android_x86 --experimental_one_version_enforcement=warning
blaze test //sensored/cpp:firestore_kokoro
blaze test //sensored/cpp:firestore_test
--
195841793 by zxu <zxu>:

Implement the wrapper class for callback (EventListener).

People unlike huge CL. So sending this short one for review. In subsequent CLs, I'll do:
*   cache/uncache or the CppEventListener class and the wiring of native method;
*   actually using this to implement DocumentReference::AddSnapshotListener;
*   update the testapp to run android_test with callback.
--
194112388 by zxu <zxu>:

Add Android-Wrapper for DocumentReference's non-callback methods.

Tested:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/cpp:firestore_kokoro
blaze test //sensored/cpp:firestore_test
--
192445183 by zxu <zxu>:

Add Android-Wrapper for Firestore's remaining methods.
Tested:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/cpp:firestore_kokoro
blaze test //sensored/cpp:firestore_test
--
190986604 by mcg <mcg>:

Manually import the public portion of

  - 22c226af3f5570514d3d13d82a399577ecd7d280 C++ migration: make Timestamp class a part of public API ... by Konstantin Varlamov <var-const@users.noreply.github.com>

Note that this only imports the header, which otherewise won't come over with a
regular copybara run because we're currently excluding the public headers from
the Firestore import with cl/188810622.

The .cc implementation of this will come over with a regular copybara import,
coming shortly.
--
189013767 by zxu <zxu>:

Add Android-Wrapper for Firestore's method that does not involve other Firestore types.
Tested:
blaze test //sensored/testapp:testapp_build_test
blaze test //sensored/testapp:testapp_build_test --config=android_x86
blaze test //sensored/cpp:firestore_kokoro
--
188809445 by mcg <mcg>:

Import of firebase-ios-sdk from Github.

  - 07f46953979d5e455db733cf2dbed481e8651de5 Updates Changelog for 4.5.0 release (#908) by Zsika Phillip <protocol86@users.noreply.github.com>
  - 2b82a2eef7e897203a191adca996435d091fe4c2 Allow serializing arbitrary length FieldValues (#889) by rsgowman <rgowman>
  - 3e41f2585cefaef1d37f76224cdd8e8908c529da Fix test failures that occur during prod build (#910) by rsgowman <rgowman>
  - f122cf7ce802972bd2fea45acac3deae2affcafa Fix MutationQueue issue resulting in re-sending acknowled... by Michael Lehenbauer <mikelehen@gmail.com>
  - 7522314812b934884f8877d36a66a4686f424a8f Partial wrapping of pb_ostream_t (pt2) (#903) by rsgowman <rgowman>
  - 0d3adb172bfdea5af23a937f3ec3aea32f739c4a Partial wrapping of pb_ostream_t (pt1) (#899) by rsgowman <rgowman>
  - e41f4b1857e13c223d8a639329cc784d603ac66e Merge Release 4.10.1 into Master (#896) by zxu <zxu>
  - 2ae36f1e9671b40723dd06462b4a416e4baa5a57 [De]Serialize FieldValue map_values ("Objects") (#878) by rsgowman <rgowman>
  - 5930ad2feebc6628cbaec89b8f6a6146ed6afe5d Factor out a universal build script (#884) by Gil <mcg>
  - 8ef0f1490a72fd700f609dc9971ec16868d6747b Adds Email link sign-in (#882) by Paul Beusterien <paulbeusterien>
  - 0b8f216e4ce85b968ac0803d729cd24eb110d0b6 Merge pull request #880 from firebase/release-4.10.0 by Paul Beusterien <paulbeusterien>
  - 8311c6432ecff78bedd13e27f64d241659324786 port paths to FSTDocumentKey (#877) by zxu <zxu>
  - 34ebf10b0acc65f1924d723e82085d4104bc281d Add 10 second timeout waiting for connection before clien... by Michael Lehenbauer <mikelehen@gmail.com>
  - 1c40e7aada6b32bbc621f06fb5f380149606a58d add converters and port paths to FSTQuery (#869) by zxu <zxu>
  - 9b5b4d876eb77e65b3246614855088be101eebf3 Serialize (and deserialize) string values (#864) by rsgowman <rgowman>
  - c6f73f7218360b364e1feb85489c58d837b575fc Fix the issue completion handler is not triggered in subs... by Chen Liang <chliang>
  - 1ecf690259c3d8ba6c34d0bd18178129bd2b9344 Add FieldValue.boolean_value() (#862) by rsgowman <rgowman>
  - 3e7c062f3baca83fae1937bf60865be0cd18f96d replacing Auth by C++ auth implementation (#802) by zxu <zxu>
  - 13aeb61de4fac4c0239bcf44a98a7d3aa9203963 Eliminate TypedValue and serialize direct from FieldValue... by rsgowman <rgowman>
--
187049498 by mcg <mcg>:

Import of firebase-ios-sdk from Github.

  - f7d9f29d53d49bdc1bf8bbadce7cf1df43fa7e1c Fix lint warnings (#840) by Gil <mcg>
  - b5c60ad91d675a263c22fb79dff9d1cda4ec4b91 Refactor [En|De]codeVarint to be symetric wrt tags (#837) by rsgowman <rgowman>
  - ddc12c0fc194a30c792d23f12120ad0703859b73 Merge pull request #694 from morganchen12/auth-docs by Morgan Chen <morganchen12@gmail.com>
  - 442d46fb9b013d5b6204891154df8625eb1cd83d Avoid warnings about failing to override a designated ini... by Gil <mcg>
  - 4dc63f8d7cbf60417b88c6a77839ea32656627b9 Fix Firestore tests for M22 (#834) by Gil <mcg>
  - 935f3ca7d749f96c7207236a39c57f32a02c05d3  Avoid wrapping and rewrapping NSStrings when constructin... by Gil <mcg>
  - 6ce954a791a73abc8d32765e2695ed153e120c47 Serialize (and deserialize) int64 values (#818) (#829) by rsgowman <rgowman>
  - 41dcd4bd17708779b45982d9547215924f2e5fd5 Fix trivial mem leak in the test suite (#828) by rsgowman <rgowman>
  - 50f9df9240007fa8bb336d7b7867919d67f3030b Accept FIRTimestamp where NSDate is currently accepted as... by Konstantin Varlamov <var-const@users.noreply.github.com>
  - 67b068e528ace4970cb21912ce9350cc1d0e292d Fix implicit retain self warnings (#808) by rsgowman <rgowman>
  - 14ea068f5fd03a658017f8472a4078a727fabc3a Make FSTTimestamp into a public Firestore class (#698) by Konstantin Varlamov <var-const@users.noreply.github.com>
  - de00de25deebc35c4c7167135d5b1f29a7d9fe6f [En|De]codeUnsignedVarint -> [En|De]codeVarint (#817) by rsgowman <rgowman>
  - 9bf73ab5f06c0cf03a43e99a24527e37ccd12ea7 Fix two stream close issues (b/73167987, b/73382103). (#8... by Michael Lehenbauer <mikelehen@gmail.com>
  - 7a4a2ea10844afd6a58dace46854fae74399f55c replacing FSTGetTokenResult by C++ Token implementation (... by zxu <zxu>
  - a9f3f35d483f1031ef2e2860aeda921f56e1bf08 Delete stale Firestore instances after FIRApp is deleted.... by Ryan Wilson <wilsonryan>
  - aa6f1ae0993ed948fb0b39283561bb3321eea5e9 Disable -Wrange-loop-analysis for abseil (#807) by rsgowman <rgowman>
  - ef55eeff4288404ed92d7a3455005aa153dd1eaf Require official 1.4.0 for min CocoaPods version (#806) by Paul Beusterien <paulbeusterien>
  - 7cddb97a607a773d8a5c70f4b73b4c132e1dc0e0 Serialize (and deserialize) bool values (#791) by rsgowman <rgowman>
  - 7a97f6c2abf39752bb66a520d57bc6e9c11b269d Enable -Wcomma for our build; disable it for abseil. (#799) by rsgowman <rgowman>
  - 81ee594e325a922a91557d82563132f22977c947 DispatchQueue delayed callback improvements + testing (#7... by Michael Lehenbauer <mikelehen@gmail.com>
  - fd9fd271d0dba3935a6f5611a1554f2c59b696af replacing Auth/FSTUser by C++ auth implementation (#804) by zxu <zxu>
  - 6889850b251ab56186bc13765baee0c3d0f1ae61 Merge pull request #801 from firebase/release-4.9.0 by Paul Beusterien <paulbeusterien>
  - e4be2548b5f85497d13c9291b4b5b76f301faa2e Fixed capitalization of init in test function. (#797) by Ryan Wilson <wilsonryan>
  - 933be73191d654bf6db01814994e54f7fe0c0136 Improve documentation on auto-init property in FCM. (#792) by Chen Liang <chliang>
  - 0f3c24b22fb6f708c8c0b55321fd21be7b0b0bd2 Actually ignore events on inactive streams, rather than j... by Greg Soltis <gsoltis>
  - fe19fca0e521e3765e4ecf6a87b0a3d622a52b92 Serialize and deserialize null (#783) by rsgowman <rgowman>
  - 95d0411e207e3eea64c035258745021ae20b676a fix flaky test (#788) by zxu <zxu>
  - b6613bdba73eaf542373ea11a9afeb04cf3b4743 Cleaning up implicit retain for the RTDB and Storage by Sebastian Schmidt <mrschmidt>
  - 5f5f80825820487e1c7ed964c94a472e84adc552 Keep track of number of queries in the query cache (#776) by Greg Soltis <gsoltis>
  - c7c51a72d2c08284d3054730f6d40f86c9d579e2 Fix double parsing on 32 bit devices. (#787) by Ryan Wilson <wilsonryan>
  - 95045820a72d6d7de2274c0bd7632f11dee53ffa Port Firestore Document to C++ (#777) by zxu <zxu>
  - adf9fb31eeef639ef23b2ff22a71adaa91a263b7 Update FieldValue of type Reference (#775) by zxu <zxu>
  - 4afcfb1b11a9ab2cd3ae4ee212093cce845a5978 Move to explicit nil check. (#782) by Ryan Wilson <wilsonryan>
  - fd83e078a271ceddd0a04c4e4880b4ce1ef34ce5 Strawman C++ API (#763) by rsgowman <rgowman>
  - 80033485be537acaf29924f6b717c777b550a418 C++ port: add C++ equivalent of FSTDocumentKey. (#762) by Konstantin Varlamov <var-const@users.noreply.github.com>
  - 612d99c759741bd6384102f586aed1b3874cf95b Fix Core CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings (#... by Paul Beusterien <paulbeusterien>
  - bf45a15e4fcae11cde33bec23e7021d430b9af5f port Firestore SnapshotVersion in C++ (#767) by zxu <zxu>
  - d70c23ece0abf7e1c00166e26fa89a670d34a740 port Firestore Auth module in C++ (#733) by zxu <zxu>
  - 633eb7bb8bbce2d31d682bf5255d9ef5a97a29c5 Let Travis run for `CMake` test and `lint.sh` (#769) by zxu <zxu>
  - 274fe52bbf817ef9d35638effb4de08454acfc6d cmake build fixes (#770) by rsgowman <rgowman>
--
184568931 by mcg <mcg>:

Import of firebase-ios-sdk from Github.

  - 32266c5d1cf700b37900911860888bb106088220 Make sure Firestore/core/include is in the podspec (#748) by Gil <mcg>
  - 070c0ea92fa8bf37bc9e5479aa2e769f796d5de4 Merge pull request #746 from morganchen12/unguarded-block by Morgan Chen <morganchen12@gmail.com>
  - 13f572ea2c57e2cd4c9c2c7c1a7c3b7f338f9fdc Increase expectation timeout to 25 seconds. (#744) by Michael Lehenbauer <mikelehen@gmail.com>
  - 47d81fdf658cc404aeccf0b408d463b8c3538a91 fix (#739) by Chen Liang <chliang>
  - 515625c47fab947f82d7f8fc8daef885e56a7df6 Remove predecessorKey,Object,Document, etc (#735) by Gil <mcg>
  - ac3052223465ce654457fec17b34f27de1706e57 Start on ArraySortedMap in C++ (#721) by Gil <mcg>
  - 729b8d176c75ecc0cbbd137cc6811116a64e310a Move all Firestore Objective-C to Objective-C++ (#734) by Gil <mcg>
  - 693d0649bfcc9c32201e2431ae08ea85fdbdb617 Merge pull request #732 from OleksiyA/FCM-subscribe-compl... by Oleksiy Ivanov <oleksiy@informationrd.com>
  - 3cbdbf2652202a3473271ed298ff50e5797cce68 Schema migrations for LevelDB (#728) by Greg Soltis <gsoltis>
  - 6474a82fd6e0e10b2cf97c4dc531e837ec97792b Firestore DatabaseId in C++ (#727) by zxu <zxu>
  - 05ef5aea13fdc60a6df74212c1bf7976f11b49de Add absl_strings to firebase_firestore_util_test dependen... by rsgowman <rgowman>
  - 03a006920f8744811358f702102e5685bbe6321b Add changelog entry for my last PR (oops) and also add a ... by Michael Lehenbauer <mikelehen@gmail.com>
  - 5a280ca1d62ac3750bf590328e3d08e0e3342cfc  Import iterator_adaptors from google3 (#718) by Gil <mcg>
  - 63a380ba33b59b571d7abd7b4565b5e63eb4680d Use fixed-sized types (#719) by Gil <mcg>
  - 6dc13731f6510ccb476a95f3af52c3f62763ef6a Version updates to 4.8.2 (#722) by Paul Beusterien <paulbeusterien>
  - a74d39f02b93c2e7bf121b33ab2164a9ac34e66b Fix a number of c++ build errors (#715) by rsgowman <rgowman>
  - cceeec3e7b2995d633deda6852cf3b40d07f9247 travis: check for copyright in sources (#717) by Paul Beusterien <paulbeusterien>
  - 4d7c9733691396503d9abc413cb6c8547ab938c5 Fix b/72502745: OnlineState changes cause limbo document ... by Michael Lehenbauer <mikelehen@gmail.com>
  - af6976a907b0d2a9fadbb14d7258bab44f075364 normalize and port the rest of Firebase/Port code (#713) by zxu <zxu>
  - 7226b4adf38e4732dfb9a840d25f86d3e5533bdb port TargetIdGenerator to iOS (#709) by zxu <zxu>
  - 53064743963d7e5cc12f7a42bb036814f5a6df17 adding unit test for auto init enable function (#710) by Chen Liang <chliang>
  - 821fb909a3007f697ad96d83c6b8e8cc70df0b6b implement `TargetIdGenerator` in C++ for Firestore (#701) by zxu <zxu>
  - 5fdda3fa837f3138973d754f05aec7f541f806ce normalize string_util (#708) by zxu <zxu>
  - 15a2926dcb986a84cf9969d7d20439d4ac2e46af Update CHANGELOG for M21.1 release (#679) by Ryan Wilson <wilsonryan>
  - f0272149c5e74c3e67aa3fb82b096179aa9284d2 Fix incorrect deprecation message (#688) by Iulian Onofrei <6d0847b9@opayq.com>
  - bfa0e40795ba676fd02d616794cce1c9b2d6a95f Implement the rest of FieldValue types for C++ (#687) by zxu <zxu>
  - 1f772120365641eb66f0cc9db9975721c8285d6e Properly publish Abseil sources as a part of the podspec ... by Gil <mcg>

ORIGINAL_AUTHOR=Firebase <firebase-noreply>
PiperOrigin-RevId: 197713382

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
